### PR TITLE
Adding path of T_classProb.mat in diffusion_maps.m and updating README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ $ ./run_identifier_cluster --email your@email.com --cores 4 --mem 128 --time 600
     - Deep Learning Toolbox
     - Image Processing Toolbox
     - Statistics and Machine Learning Toolbox
+    - Control System Toolbox
 
 ## FAQ
 - Will `VocalMat` work with my MATLAB version?

--- a/vocalmat_analysis/diffusion_maps.m
+++ b/vocalmat_analysis/diffusion_maps.m
@@ -9,6 +9,7 @@
 % -- Copyright (c) 2020 Dietrich Lab - Yale University
 % ----------------------------------------------------------------------------------------------
 
+load(strcat(vfile, '\T_classProb.mat'));
 T_classProb_orig = T_classProb;
 T_classProb(strcmp(T_classProb.DL_out,'noise_dist'),:)=[]; %Remove noise
 T_classProb.DL_out(strcmp(T_classProb.DL_out,'chevron'))={1};


### PR DESCRIPTION
# Adding path of T_classProb.mat in diffusion_maps.m 

When `run('diffusion_maps.m')` runs from `VocalMat.m`, it gave an error at the line `T_classProb(strcmp(T_classProb.DL_out,'noise_dist'),:)=[]; %Remove noise`
 telling dot indexing is not supported. It turns out that `T_classProb` was a matrix not a table. So, I loaded the table from the saved matfile.

# README

In README, added `Control System Toolbox`

P.S The code works well in MATLAB 2022b. Thank you for open sourcing the code ❤️  